### PR TITLE
Support multiple magic.h header place.

### DIFF
--- a/cffi-grovel-patch.lisp
+++ b/cffi-grovel-patch.lisp
@@ -1,5 +1,15 @@
 (in-package :cffi-grovel)
 
+(define-grovel-syntax include-or (&rest file-names)
+  (loop
+     for file-name in file-names
+     if (probe-file file-name)
+     do
+       (return
+         (format out "#include <~A>~%" file-name))))
+
+(push 'include-or *header-forms*)
+
 ;; Defines a bitfield, with elements specified as ((lisp-name c-name)
 ;; &key documentation).  name-and-opts can be either a symbol as name,
 ;; or a list (name &key base-type).

--- a/grovel.lisp
+++ b/grovel.lisp
@@ -1,6 +1,7 @@
 (in-package :magicffi)
 
-(include "/usr/local/include/magic.h")
+(include-or "/usr/include/magic.h"
+            "/usr/local/include/magic.h")
 
 (progn
   (constant (+MAGIC-NONE+ "MAGIC_NONE")

--- a/grovel.lisp
+++ b/grovel.lisp
@@ -1,6 +1,6 @@
 (in-package :magicffi)
 
-(include "/usr/include/magic.h")
+(include "/usr/local/include/magic.h")
 
 (progn
   (constant (+MAGIC-NONE+ "MAGIC_NONE")


### PR DESCRIPTION
Sometims (on my system) magic.h placed under /usr/loca/include .
So support both place.