### PR TITLE
Add include entry for /opt/homebrew

### DIFF
--- a/grovel.lisp
+++ b/grovel.lisp
@@ -1,7 +1,8 @@
 (cl:in-package :magicffi)
 
 (include-or "/usr/include/magic.h"
-            "/usr/local/include/magic.h")
+            "/usr/local/include/magic.h"
+            "/opt/homebrew/include/magic.h")
 
 (progn
  (constant (+magic-none+ "MAGIC_NONE") :documentation "No flags")


### PR DESCRIPTION
Hi, I had to add this entry for a macOS running homebrew on "apple silicon".